### PR TITLE
Run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN useradd --system tideways \
 EXPOSE 9135
 USER tideways
 
-ENTRYPOINT ["tideways-daemon", "--address=0.0.0.0:9135", "--hostname=$TIDEWAYS_HOSTNAME"]
+ENTRYPOINT ["/bin/sh", "-c", "tideways-daemon --address=0.0.0.0:9135 --hostname=$TIDEWAYS_HOSTNAME"]


### PR DESCRIPTION
Matching instructions on https://support.tideways.com/documentation/setup/installation/docker-with-compose.html#tideways-daemon-dockerized from 2021-03-16